### PR TITLE
Adds Riot shotguns to Cargo

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -483,6 +483,20 @@
 					/obj/item/storage/belt/bandolier,
 					/obj/item/storage/belt/bandolier)
 	crate_name = "combat shotguns crate"
+/datum/supply_pack/security/armory/riotshotgun
+        name = "Riot Shotguns Crate"
+        desc = "Tip: techically, it counts as non-lethally subduing a target as long as they don't die before Medbay can get to them. Contains three security-grade riot shotguns. Requires Armory access to open."
+	cost = 6500
+        contains = list(/obj/item/gun/ballistic/shotgun/riot,
+   					/obj/item/gun/ballistic/shotgun/riot,
+					/obj/item/gun/ballistic/shotgun/riot)
+        crate_name = "riot shotguns crate"
+/datum/supply_pack/security/armory/riotshotgun_single
+	name = "Riot Shotgun Single-Pack"
+        desc = "Stop that Clown in his tracks with this magic stick of non-lethal subduction! Contains one security-grade riot shotgun. Requires Armory access to open."
+        cost = 2250 
+        small_item = TRUE
+        contains = list(/obj/item/gun/ballistic/shotgun/riot)
 
 /datum/supply_pack/security/armory/dragnet
 	name = "DRAGnet Crate"


### PR DESCRIPTION
Allows security to use a ballistic weapon other than the autorifle and the bulky combat shotgun. Also fixes the issue with only having a few roundstart riot shotguns which cannot be replenished. 


Mirrored from : https://github.com/tgstation/tgstation/pull/47096

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds riot shotguns to cargo, which can usually only be found in the armory. Allows for a cheaper and more ergonomic alternative to the combat shotgun during War Ops or Clock Cultists. 


## Why It's Good For The Game
Allows security to use a ballistic weapon other than the autorifle and the bulky combat shotgun. Also fixes the issue with only having a few roundstart riot shotguns which cannot be replenished.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added new things
add: Added more things
del: Removed old things
tweak: tweaked a few things
balance: rebalanced something
fix: fixed a few things
soundadd: added a new sound thingy
sounddel: removed an old sound thingy
imageadd: added some icons and images
imagedel: deleted some icons and images
spellcheck: fixed a few typos
code: changed some code
refactor: refactored some code
config: changed some config setting
admin: messed with admin stuff
server: something server ops should know
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
